### PR TITLE
Docs: ブランチの説明を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,17 @@
 VuePress で生成してる技術ブログ  
 何かしら引っかかったところとかのメモ代わり
 
-ソースを管理する source ブランチとビルドした結果を管理する master ブランチに分けてます
+~~ソースを管理する source ブランチとビルドした結果を管理する master ブランチに分けてます~~
+
+GitHub Pages が指定ブランチの `/docs` 指定で公開できるようになってたので `master` だけ管理するように変更した
 
 ```
 git clone https://github.com/taku-ando/taku-ando.github.io.git
 cd taku-ando.github.io
-yarn install
-yarn run dev
+
+# dev
+yarn && yarn dev
+
+# build
+yarn && yarn build
 ```


### PR DESCRIPTION
GitHub Pagesの公開するディレクトリが選べた (ルートのディレクトリか `/docs`)
`master` と `source` に分ける意味もなくなったので `master` で全部管理する